### PR TITLE
update get_allowed_tags_str so code is more readable

### DIFF
--- a/includes/abstracts/abstract-bewpi-setting.php
+++ b/includes/abstracts/abstract-bewpi-setting.php
@@ -87,12 +87,15 @@ if ( ! class_exists( 'BEWPI_Abstract_Setting' ) ) {
 	     * @return string|void
 	     */
 	    protected function get_allowed_tags_str() {
-		    ( count( $this->allowed_tags ) > 0 ) ? $str = __( 'Allowed HTML tags: ', 'be-woocommerce-pdf-invoices' ) : $str = '';
-		    foreach ( $this->allowed_tags as $i => $tag ) {
-			    ( $i == count( $this->allowed_tags ) - 1 ) ? $str .= sprintf( '<code>%s</code>.', htmlspecialchars( $tag ) ) : $str .= sprintf( '<code>%s</code> ', htmlspecialchars( $tag ) );
+
+		    if( empty( $this->allowed_tags ) ) {
+			    return '';
 		    }
 
-		    return $str;
+		    $encoded_tags = array_map( 'htmlspecialchars', $this->allowed_tags );
+		    $tags_string = '<code>' . join( '</code>, <code>', $encoded_tags ) . '</code>';
+
+			return __( 'Allowed HTML tags: ', 'be-woocommerce-pdf-invoices' ) . $tags_string . '.';
 	    }
 
 	    public function select_callback( $args ) {


### PR DESCRIPTION
I noticed some code in the `get_allowed_tags_str()` method which took me a while to figure out. 

Updated the method to be a bit more readable (and slightly better performing but that's not really important in this case, as the method doesn't run that often).

On a related note: you do not need to add the self-closing tag separately. Just `<br>` will work fine. :)