### PR TITLE
[PATCH] Add support for third-party numbering plugins

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -24,6 +24,34 @@ Settings.enableDisableNextInvoiceNumbering = function (elem) {
     ( elem.checked ) ? nextInvoiceNumberInput.disabled = false : nextInvoiceNumberInput.disabled = true;
 };
 
+Settings.showHideInvoiceNumberOptions = function (elem) {
+    // The Element.closest function is new in DOM5, so to be sure, we don't use it yet
+    var closest = function(el, tag) {
+        for ( ; el && el !== document; el = el.parentNode ) {
+        if ( el.tagName.toLowerCase() === tag ) {
+                return el;
+            }
+        }
+        return false;
+    };
+    var showHideControl = function(id, show) {
+        var e = document.getElementById(id);
+        // Also hide the whole table row
+        closest(e, 'tr').style.display = (show) ? '' : 'none';
+    };
+    if (!elem) return;
+    var val = (elem.options[elem.selectedIndex].value);
+    // Show / hide the table rows with controls that do not apply to the current invoice numbering type
+    showHideControl('bewpi-reset-counter', val == "sequential_number");
+    showHideControl('bewpi-next-invoice-number', val == "sequential_number");
+    showHideControl('bewpi-invoice-number-digits', val != "third_party");
+    showHideControl('bewpi-invoice-number-prefix', val != "third_party");
+    showHideControl('bewpi-invoice-number-suffix', val != "third_party");
+    showHideControl('bewpi-invoice-number-format', val != "third_party");
+    showHideControl('bewpi-reset-counter-yearly', val == "sequential_number");
+};
+
+
 jQuery( function ( $ ) {
 // Tooltips
     var tiptip_args = {

--- a/includes/abstracts/abstract-bewpi-invoice.php
+++ b/includes/abstracts/abstract-bewpi-invoice.php
@@ -124,6 +124,12 @@ if ( ! class_exists( 'BEWPI_Abstract_Invoice' ) ) {
          */
         public function get_formatted_number()
         {
+            // Check if the users uses a third-party numbering plugin
+            if ( $this->template_options[ 'bewpi_invoice_number_type' ] == "third_party" ) {
+                return apply_filters( 'woocommerce_invoice_number',
+                                      $this->order->id, // Default is order ID
+                                      $this->order->id );
+            }
             $invoice_number_format = $this->template_options['bewpi_invoice_number_format'];
             // Format number with the number of digits
             $digit_str = "%0" . $this->template_options['bewpi_invoice_number_digits'] . "s";
@@ -252,6 +258,13 @@ if ( ! class_exists( 'BEWPI_Abstract_Invoice' ) ) {
 
         private function get_next_invoice_number()
         {
+            // Check if the users uses a third-party numbering plugin
+            if ( $this->template_options[ 'bewpi_invoice_number_type' ] == "third_party" ) {
+                return apply_filters( 'woocommerce_generate_invoice_number',
+                                      $this->order->id, // Default is order ID
+                                      $this->order );
+            }
+
             // check if user uses the built in WooCommerce order numbers
             if ($this->template_options['bewpi_invoice_number_type'] !== "sequential_number")
                 return $this->order->get_order_number();

--- a/includes/abstracts/abstract-bewpi-setting.php
+++ b/includes/abstracts/abstract-bewpi-setting.php
@@ -101,7 +101,13 @@ if ( ! class_exists( 'BEWPI_Abstract_Setting' ) ) {
 	    public function select_callback( $args ) {
 		    $options = get_option( $args['page'] );
 		    ?>
-		    <select id="<?php echo $args['id']; ?>" name="<?php echo $args['page'] . '[' . $args['name'] . ']'; ?>">
+		    <select id="<?php echo $args['id']; ?>" name="<?php echo $args['page'] . '[' . $args['name'] . ']'; ?>" <?php
+			    if ( isset ( $args['attrs'] ) ) :
+				    foreach ( $args['attrs'] as $attr ) :
+					    echo $attr . ' ';
+				    endforeach;
+			    endif;
+			    ?> >
 			    <?php
 			    foreach ( $args['options'] as $option ) :
 				    ?>

--- a/includes/admin/settings/class-bewpi-admin-settings-template.php
+++ b/includes/admin/settings/class-bewpi-admin-settings-template.php
@@ -271,7 +271,10 @@ if ( ! class_exists( 'BEWPI_Template_Settings' ) ) {
 				    'page' => $this->settings_key,
 				    'section' => 'invoice_number',
 				    'type' => 'text',
-				    'desc' => '',
+				    'desc' => '<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function(){
+    Settings.showHideInvoiceNumberOptions(document.getElementById("bewpi-invoice-number-type"));
+});</script>',
 				    'options' => array(
 					    array(
 						    'name' => __( 'WooCommerce order number', 'woocommerce-pdf-invoices' ),
@@ -280,9 +283,16 @@ if ( ! class_exists( 'BEWPI_Template_Settings' ) ) {
 					    array(
 						    'name' => __( 'Sequential number', 'woocommerce-pdf-invoices' ),
 						    'value' => 'sequential_number'
-					    )
+					    ),
+					    array(
+						    'name' => __( 'Third-Party numbering plugin', 'woocommerce-pdf-invoices' ),
+						    'value' => 'third_party',
+						),
 				    ),
-				    'default' => 'sequential_number'
+				    'default' => 'sequential_number',
+				    'attrs' => array(
+					    'onchange="Settings.showHideInvoiceNumberOptions(this)"',
+				    )
 			    ),
 			    array(
 				    'id' => 'bewpi-reset-counter',

--- a/includes/be-woocommerce-pdf-invoices.php
+++ b/includes/be-woocommerce-pdf-invoices.php
@@ -160,7 +160,7 @@ if ( ! class_exists( 'BE_WooCommerce_PDF_Invoices' ) ) {
 
 				$tags = array (
 					'{formatted_invoice_number}'    => $invoice->get_formatted_number(),
-					'{order_number}'                => $order->id,
+					'{order_number}'                => $order->get_order_number(),
 					'{formatted_invoice_date}'      => $invoice->get_formatted_invoice_date(),
 					'{formatted_order_date}'        => $invoice->get_formatted_order_date()
 				);


### PR DESCRIPTION
  -) Add third option for invoice numbers: "Third-party plugin"
  -) If selected, use the invoice numbers returned by the woocommerce_invoice_number filter
  -) Add JS to show/hide the counter configuration settings, when not needed (i.e. for order ID and/or third-party plugin)

This implements the API proposed at
http://open-tools.net/blog/63-proposal-for-a-general-api-for-third-party-woocommerce-invoice-numbering-plugins.html
for the "WooCommerce PDF Invoices" plugin by Bas Elbers (woocommerce-pdf-invoices)
