### PR TITLE
Remove extra PHP tags on line 54

### DIFF
--- a/includes/templates/invoices/simple/micro/body.php
+++ b/includes/templates/invoices/simple/micro/body.php
@@ -50,8 +50,9 @@ echo $this->outlining_columns_html( count( $this->order->get_taxes() ) );
 		<!-- Description -->
 		<th class="align-left"><?php _e( 'Description', 'woocommerce-pdf-invoices' ); ?></th>
 		<!-- SKU -->
-		<?php if ( $this->template_options['bewpi_show_sku'] ) { ?>
-			<?php $columns_count++; ?>
+		<?php if ( $this->template_options['bewpi_show_sku'] ) {
+			$columns_count++;
+		?>
 			<th class="align-left"><?php _e( 'SKU', 'woocommerce-pdf-invoices' ); ?></th>
 		<?php } ?>
 		<!-- Cost -->


### PR DESCRIPTION
Fixes the setting to toggle SKU as a visible column in the PDF invoice. Thanks for the plugin  👍