### PR TITLE
Wrap Composer autoload.php in file_exists() conditional

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -44,7 +44,9 @@ function _bewpi_load_plugin() {
 	define( 'WPI_FILE', __FILE__ );
 	define( 'WPI_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 
-	require_once WPI_DIR . '/vendor/autoload.php';
+	if ( file_exists( WPI_DIR . '/vendor/autoload.php' ) ) {
+		require_once WPI_DIR . '/vendor/autoload.php';
+	}
 
 	/**
 	 * Main instance of BE_WooCommerce_PDF_Invoices.


### PR DESCRIPTION
I'm using Composer to manage plugins on my WP setup. Of course Composer only creates one global vendor dir and autoload.php for the entire project which means no vendor dir or autoload.php will be generated in the WPI plugin dir.